### PR TITLE
Use the 'latest' download link

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -6,6 +6,7 @@
 class hipchat {
   package { 'HipChat':
     provider => 'compressed_app',
-    source   => 'http://downloads.hipchat.com.s3.amazonaws.com/osx/HipChat-2.5.4-83.zip'
+    source   => 'https://www.hipchat.com/downloads/latest/mac',
+    flavor   => 'zip',
   }
 }

--- a/spec/classes/hipchat_spec.rb
+++ b/spec/classes/hipchat_spec.rb
@@ -5,7 +5,8 @@ describe 'hipchat' do
     should contain_class('hipchat')
     should contain_package('HipChat').with({
       :provider => 'compressed_app',
-      :source   => 'http://downloads.hipchat.com.s3.amazonaws.com/osx/HipChat-2.5.4-83.zip'
+      :source   => 'https://www.hipchat.com/downloads/latest/mac',
+      :flavor   => 'zip',
     })
   end
 end


### PR DESCRIPTION
Use 'latest' link, which redirects to the real file.
Specify the flavor, since there's no file extension to guess from.

This fixes #7, which does not work for me in its current form (because the flavor doesn't get guessed).

I'm not familiar with how Boxen handles updating installed applications. The receipt file created here gives the source as the generic "latest" link, so that might be a problem.
